### PR TITLE
gitignore: create/update them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *pyc
 *_flymake.py
 */*_flymake.py
+/build/
+/lib/
+/scripts-*


### PR DESCRIPTION
externalsrc depends on a revision created with git add -A. Up to date gitignore would prevent unecessary rebuilds.